### PR TITLE
fix(typo): should pass exports to factory when amd

### DIFF
--- a/src/walkway.js
+++ b/src/walkway.js
@@ -13,7 +13,7 @@
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
     define(['exports'], function (exports) {
-      factory(root);
+      factory(exports);
     });
   } else if (typeof exports === 'object') {
     // CommonJS


### PR DESCRIPTION
is this a typo? if it is amd, we should pass exports object to factory instead of root, isn't it?
