### PR TITLE
Correct broken "main" path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "walkway.js",
   "version": "0.0.3",
   "description": "An easy way to animate simple svg elements.",
-  "main": "/src/walkway.js",
+  "main": "src/walkway.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
`package.json` requires a relative path for the  `main` script ([ref](https://www.npmjs.org/doc/files/package.json.html#main)). Currently, the library uses an absolute path and is broken when installing via NPM (I'm running version `1.4.28`).

Fixing this will mean the library is usable with tools like [Browserify](http://browserify.org/).
