### PR TITLE
Fixed polyline support in Internet Explorer

### DIFF
--- a/src/walkway.js
+++ b/src/walkway.js
@@ -325,11 +325,11 @@
     var dist = 0;
     var x1, x2, y1, y2;
 
-    for(var i = 1; i < polyline.points.length; i++){
-      x1 = polyline.points[i - 1].x;
-      x2 = polyline.points[i].x;
-      y1 = polyline.points[i - 1].y;
-      y2 = polyline.points[i].y;
+    for(var i = 1; i < polyline.points.numberOfItems; i++){
+      x1 = polyline.points.getItem(i - 1) .x;
+      x2 = polyline.points.getItem(i).x;
+      y1 = polyline.points.getItem(i - 1) .y;
+      y2 = polyline.points.getItem(i).y;
 
       dist += Math.sqrt(Math.pow((x1 - x2), 2) + Math.pow((y1 - y2), 2));
     }


### PR DESCRIPTION
Hey, 

I just noticed that there's some methods I was relying on that don't work in IE. Not sure why at all, but this code should work for all browsers now.
