### PR TITLE
Adding redraw logic on changing tab active state

### DIFF
--- a/src/walkway.js
+++ b/src/walkway.js
@@ -9,349 +9,442 @@
  */
 
 // Export Walkway depending on environment (AMD, CommonJS or Browser global)
-;(function(root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    // AMD. Register as an anonymous module.
-    define(factory);
-  } else if (typeof exports === 'object') {
-    // CommonJS
-    module.exports = factory();
-  } else {
-    // Browser globals
-    root.Walkway = factory();
-  }
+;
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(factory);
+    } else if (typeof exports === 'object') {
+        // CommonJS
+        module.exports = factory();
+    } else {
+        // Browser globals
+        root.Walkway = factory();
+    }
 }(this, function factory(exports) {
-  'use strict';
+    'use strict';
 
-  /*
-   * Shim for requestAnimationFrame on older browsers
-   */
+    /*
+     * Shim for requestAnimationFrame on older browsers
+     */
 
-  var lastTime = 0;
-  window.requestAnimationFrame = window.requestAnimationFrame || window.mozRequestAnimationFrame || window.webkitRequestAnimationFrame || window.msRequestAnimationFrame;
-  window.cancelAnimationFrame = window.cancelAnimationFrame || window.mozCancelAnimationFrame;
+    var lastTime = 0;
+    window.requestAnimationFrame = window.requestAnimationFrame || window.mozRequestAnimationFrame || window.webkitRequestAnimationFrame || window.msRequestAnimationFrame;
+    window.cancelAnimationFrame = window.cancelAnimationFrame || window.mozCancelAnimationFrame;
 
-  if (!window.requestAnimationFrame) {
-    window.requestAnimationFrame = function(callback, element) {
-      var currTime = new Date().getTime();
-      var timeToCall = Math.max(0, 16 - (currTime - lastTime));
-      var id = window.setTimeout(function() {
-        callback(currTime + timeToCall);
-      }, timeToCall);
+    if (!window.requestAnimationFrame) {
+        window.requestAnimationFrame = function (callback, element) {
+            var currTime = new Date().getTime();
+            var timeToCall = Math.max(0, 16 - (currTime - lastTime));
+            var id = window.setTimeout(function () {
+                callback(currTime + timeToCall);
+            }, timeToCall);
 
-      lastTime = currTime + timeToCall;
-      return id;
+            lastTime = currTime + timeToCall;
+            return id;
+        };
+    }
+
+    if (!window.cancelAnimationFrame) {
+        window.cancelAnimationFrame = function (id) {
+            clearTimeout(id);
+        };
+    }
+
+    /*
+     * Easing Functions - inspired from http://gizma.com/easing/
+     * only considering the t value for the range [0, 1] => [0, 1]
+     *
+     * Taken from https://gist.github.com/gre/1650294
+     */
+
+    var EasingFunctions = {
+        // no easing, no acceleration
+        linear: function (t) {
+            return t;
+        },
+        // accelerating from zero velocity
+        easeInQuad: function (t) {
+            return t * t;
+        },
+        // decelerating to zero velocity
+        easeOutQuad: function (t) {
+            return t * (2 - t);
+        },
+        // acceleration until halfway, then deceleration
+        easeInOutQuad: function (t) {
+            return t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+        },
+        // accelerating from zero velocity
+        easeInCubic: function (t) {
+            return t * t * t;
+        },
+        // decelerating to zero velocity
+        easeOutCubic: function (t) {
+            return (--t) * t * t + 1;
+        },
+        // acceleration until halfway, then deceleration
+        easeInOutCubic: function (t) {
+            return t < 0.5 ? 4 * t * t * t : (t - 1) * (2 * t - 2) * (2 * t - 2) + 1;
+        },
+        // accelerating from zero velocity
+        easeInQuart: function (t) {
+            return t * t * t * t;
+        },
+        // decelerating to zero velocity
+        easeOutQuart: function (t) {
+            return 1 - (--t) * t * t * t;
+        },
+        // acceleration until halfway, then deceleration
+        easeInOutQuart: function (t) {
+            return t < 0.5 ? 8 * t * t * t * t : 1 - 8 * (--t) * t * t * t;
+        },
+        // accelerating from zero velocity
+        easeInQuint: function (t) {
+            return t * t * t * t * t;
+        },
+        // decelerating to zero velocity
+        easeOutQuint: function (t) {
+            return 1 + (--t) * t * t * t * t;
+        },
+        // acceleration until halfway, then deceleration
+        easeInOutQuint: function (t) {
+            return t < 0.5 ? 16 * t * t * t * t * t : 1 + 16 * (--t) * t * t * t * t;
+        }
     };
-  }
 
-  if (!window.cancelAnimationFrame) {
-    window.cancelAnimationFrame = function(id) {
-      clearTimeout(id);
+    /*
+     * Creates a selector used to select all element to animate
+     * Currently only supports *path*, *line*, and *polyline* svg elements
+     *
+     * @param {string} selector The selector of the parent element
+     * @returns {string} the complete selector
+     * @private
+     */
+
+    function _createSelector(selector) {
+        var supported = ['path', 'line', 'polyline'];
+        var newSelector = supported.reduce(function (prev, curr) {
+            return prev + selector + ' ' + curr + ', ';
+        }, '');
+        // chop the last , from the string
+        return newSelector.slice(0, -2);
+    }
+
+    /*
+     * Walkway constructor function
+     * opts.selector is the only mandatory param and can be passed in alone
+     * as a string
+     *
+     * @param {object} opts the configuration objects for the instance.
+     * @returns {walkway}
+     */
+
+    function Walkway(opts) {
+        if (!(this instanceof Walkway))
+            return new Walkway(opts);
+
+        if (typeof opts === 'string')
+            opts = {selector: opts};
+
+        if (!opts.selector)
+            return this.error('A selector needs to be specified');
+
+        this.opts = opts;
+        this.selector = opts.selector;
+        this.duration = opts.duration || 500;
+        this.easing = EasingFunctions[opts.easing] || EasingFunctions.easeInOutCubic;
+        // Checking current tab state
+        this.state = opts.redrawOnFocus ? this.stateChanged() || 'visible' : null;
+        // Callback func from .draw call
+        this.drawCallback = function () {};
+        this.paths = this.getPaths();
+        this.setInitialStyles();
+        this.id = false;
+    }
+
+    /*
+     * Prints an error message to the console
+     *
+     * @param {string} message the message to be displayed
+     * @returns {void}
+     */
+
+    Walkway.prototype.error = function (message) {
+        console.log('Walkway error: ' + message);
     };
-  }
 
-  /*
-   * Easing Functions - inspired from http://gizma.com/easing/
-   * only considering the t value for the range [0, 1] => [0, 1]
-   *
-   * Taken from https://gist.github.com/gre/1650294
-   */
 
-  var EasingFunctions = {
-    // no easing, no acceleration
-    linear: function (t) { return t; },
-    // accelerating from zero velocity
-    easeInQuad: function (t) { return t*t; },
-      // decelerating to zero velocity
-    easeOutQuad: function (t) { return t*(2-t); },
-      // acceleration until halfway, then deceleration
-    easeInOutQuad: function (t) { return t<0.5 ? 2*t*t : -1+(4-2*t)*t; },
-      // accelerating from zero velocity
-    easeInCubic: function (t) { return t*t*t; },
-      // decelerating to zero velocity
-    easeOutCubic: function (t) { return (--t)*t*t+1; },
-      // acceleration until halfway, then deceleration
-    easeInOutCubic: function (t) { return t<0.5 ? 4*t*t*t : (t-1)*(2*t-2)*(2*t-2)+1; },
-      // accelerating from zero velocity
-    easeInQuart: function (t) { return t*t*t*t; },
-      // decelerating to zero velocity
-    easeOutQuart: function (t) { return 1-(--t)*t*t*t; },
-      // acceleration until halfway, then deceleration
-    easeInOutQuart: function (t) { return t<0.5 ? 8*t*t*t*t : 1-8*(--t)*t*t*t; },
-      // accelerating from zero velocity
-    easeInQuint: function (t) { return t*t*t*t*t; },
-      // decelerating to zero velocity
-    easeOutQuint: function (t) { return 1+(--t)*t*t*t*t; },
-      // acceleration until halfway, then deceleration
-    easeInOutQuint: function (t) { return t<0.5 ? 16*t*t*t*t*t : 1+16*(--t)*t*t*t*t; }
-  };
+    /*
+     * Check for browser active tab state change. Will not detect switching windows by alt+tab
+     *
+     * @param {void} just addEventListener, which works with handleEvent callback function
+     * @return {void} everything sets on object
+     */
 
-  /*
-   * Creates a selector used to select all element to animate
-   * Currently only supports *path*, *line*, and *polyline* svg elements
-   *
-   * @param {string} selector The selector of the parent element
-   * @returns {string} the complete selector
-   * @private
-   */
+    Walkway.prototype.stateChanged = function () {
 
-  function _createSelector(selector) {
-    var supported = ['path', 'line', 'polyline'];
-    var newSelector = supported.reduce(function(prev, curr){
-      return prev + selector + ' ' + curr + ', ';
-    }, '');
-    // chop the last , from the string
-    return newSelector.slice(0, -2);
-  }
+        // Basic visibility checks for different browsers
+        var hidden, state, visibilityChange;
+        if (typeof document.hidden !== "undefined") { // Opera 12.10 and Firefox 18 and later support
+            hidden = "hidden";
+            visibilityChange = "visibilitychange";
+            state = "visibilityState";
+        } else if (typeof document.mozHidden !== "undefined") {
+            hidden = "mozHidden";
+            visibilityChange = "mozvisibilitychange";
+            state = "mozVisibilityState";
+        } else if (typeof document.msHidden !== "undefined") {
+            hidden = "msHidden";
+            visibilityChange = "msvisibilitychange";
+            state = "msVisibilityState";
+        } else if (typeof document.webkitHidden !== "undefined") {
+            hidden = "webkitHidden";
+            visibilityChange = "webkitvisibilitychange";
+            state = "webkitVisibilityState";
+        }
 
-  /*
-   * Walkway constructor function
-   * opts.selector is the only mandatory param and can be passed in alone
-   * as a string
-   *
-   * @param {object} opts the configuration objects for the instance.
-   * @returns {walkway}
-   */
+        // Handler for event listener
+        this.handleEvent = function (e) {
+            this.state = document[state];
 
-  function Walkway(opts) {
-    if (!(this instanceof Walkway))
-      return new Walkway(opts);
+            if (typeof this.id != 'undefined' && document[state] == 'hidden') {
+                window.cancelAnimationFrame(this.id);
 
-    if(typeof opts === 'string')
-      opts = { selector: opts };
+            } else if (typeof this.id != 'undefined' && document[state] == 'visible') {
+                // Go through every path object and set animationStart to Date.now on tab activation
+                this.paths.forEach(function (n) {
+                    n.animationStart = Date.now();
+                });
 
-    if (!opts.selector)
-      return this.error('A selector needs to be specified');
+                // Drawing with a user callback function
+                this.draw(this.drawCallback);
+            }
+        };
 
-    this.opts = opts;
-    this.selector = opts.selector;
-    this.duration = opts.duration || 500;
-    this.easing = EasingFunctions[opts.easing] || EasingFunctions.easeInOutCubic;
-    this.paths = this.getPaths();
-    this.setInitialStyles();
-    this.id = false;
-  }
+        document.addEventListener(visibilityChange, this, false);
 
-  /*
-   * Prints an error message to the console
-   *
-   * @param {string} message the message to be displayed
-   * @returns {void}
-   */
-
-  Walkway.prototype.error = function(message) {
-    console.log('Walkway error: ' + message);
-  };
-
-  /*
-   * Uses a pre-build selector to find and store elements to animate
-   *
-   * @returns {array} of Path instances
-   */
-
-  Walkway.prototype.getPaths = function() {
-    var self = this;
-    var selector = _createSelector(this.selector);
-    var els = document.querySelectorAll(selector);
-    els = Array.prototype.slice.call(els);
-
-    return els.map(function(el) {
-      if(el.tagName === 'path') {
-        return new Path(el, self.duration, self.easing);
-      } else if (el.tagName === 'line') {
-        return new Line(el, self.duration, self.easing);
-      } else if(el.tagName === 'polyline'){
-        return new Polyline(el, self.duration, self.easing);
-      }
-    });
-  };
-
-  /*
-   * Sets initial styles on all elements to be animated
-   *
-   * @returns {void}
-   */
-
-  Walkway.prototype.setInitialStyles = function() {
-    this.paths.forEach(function(n) {
-      n.el.style.strokeDasharray = n.length + ' ' + n.length;
-      n.el.style.strokeDashoffset = n.length;
-    });
-  };
-
-  /*
-   * The general update loop for the animations.
-   * Once individal paths are finished they are spliced
-   * from the array. Once the array is empty the animation is stopped.
-   *
-   * @returns {void}
-   */
-
-  Walkway.prototype.draw = function(callback) {
-    var counter = this.paths.length;
-    var path;
-
-    if (counter === 0) {
-      if (callback && typeof(callback) === 'function') {
-        callback();
-      }
-      return window.cancelAnimationFrame(this.id);
     }
 
-    while (counter--) {
-      path = this.paths[counter];
-      var done = path.update();
+    /*
+     * Uses a pre-build selector to find and store elements to animate
+     *
+     * @returns {array} of Path instances
+     */
 
-      if (done)
-        this.paths.splice(counter, 1);
+    Walkway.prototype.getPaths = function () {
+        var self = this;
+        var selector = _createSelector(this.selector);
+        var els = document.querySelectorAll(selector);
+        els = Array.prototype.slice.call(els);
+
+        return els.map(function (el) {
+            if (el.tagName === 'path') {
+                return new Path(el, self.duration, self.easing, self.opts.redrawOnFocus);
+            } else if (el.tagName === 'line') {
+                return new Line(el, self.duration, self.easing, self.opts.redrawOnFocus);
+            } else if (el.tagName === 'polyline') {
+                return new Polyline(el, self.duration, self.easing, self.opts.redrawOnFocus);
+            }
+        });
+
+    };
+
+    /*
+     * Sets initial styles on all elements to be animated
+     *
+     * @returns {void}
+     */
+
+    Walkway.prototype.setInitialStyles = function () {
+        this.paths.forEach(function (n) {
+            n.el.style.strokeDasharray = n.length + ' ' + n.length;
+            n.el.style.strokeDashoffset = n.length;
+        });
+    };
+
+    /*
+     * The general update loop for the animations.
+     * Once individal paths are finished they are spliced
+     * from the array. Once the array is empty the animation is stopped.
+     *
+     * @returns {void}
+     */
+
+    Walkway.prototype.draw = function (callback) {
+        var counter = this.paths.length;
+        var path;
+        this.drawCallback = callback;
+
+        if (counter === 0) {
+            if (callback && typeof(callback) === 'function') {
+                callback();
+            }
+            return window.cancelAnimationFrame(this.id);
+        }
+
+        while (counter--) {
+            path = this.paths[counter];
+            var done = path.update();
+
+            if (done && (path.redrawOnFocus === false || path.redrawOnFocus == undefined)) {
+                this.paths.splice(counter, 1);
+            }
+        }
+
+        this.id = window.requestAnimationFrame(this.draw.bind(this, callback));
+    };
+
+    /*
+     * This contains the general update logic for all supported svg
+     * elements. It *must* be called using .call or .apply in order
+     * to pass the correct context for the element.
+     *
+     * @returns {boolean} true if the animation is complete, false otherwise
+     */
+
+    function generalUpdate(element) {
+
+        if (!element.animationStarted) {
+            element.animationStart = Date.now();
+            element.animationStarted = true;
+        }
+
+        var progress = element.easing((Date.now() - element.animationStart) / element.duration);
+
+
+        var value = Math.ceil(element.length * (1 - progress));
+        element.el.style.strokeDashoffset = value < 0 ? 0 : Math.abs(value);
+
+        return progress >= 1 ? true : false;
     }
 
-    this.id = window.requestAnimationFrame(this.draw.bind(this, callback));
-  };
+    /*
+     * Constructor for new path instance
+     *
+     * @param {node} path actual dom node of the path
+     * @param {string} duration how long the animation should take to complete
+     * @param {string} easing the type of easing used - default is easeInOutCubic.
+     * @returns {Path}
+     */
 
-  /*
-   * This contains the general update logic for all supported svg
-   * elements. It *must* be called using .call or .apply in order
-   * to pass the correct context for the element.
-   *
-   * @returns {boolean} true if the animation is complete, false otherwise
-   */
+    function Path(path, duration, easing, redrawOnFocus) {
+        this.el = path;
+        this.length = path.getTotalLength(); // total length of the path
+        this.duration = duration;
+        this.easing = easing;
+        this.animationStart = null;
+        this.animationStarted = false;
+        this.redrawOnFocus = redrawOnFocus;
 
-  function generalUpdate(element) {
-    if (!element.animationStarted) {
-      element.animationStart = Date.now();
-      element.animationStarted = true;
     }
 
-    var progress = element.easing((Date.now() - element.animationStart) / element.duration);
-    var value = Math.ceil(element.length * (1 - progress));
-    element.el.style.strokeDashoffset = value < 0 ? 0 : Math.abs(value);
+    /*
+     * Updates path style until the animation is complete
+     *
+     * @returns {boolean} Returns true if the path animation is finished, false otherwise
+     */
 
-    return progress >= 1 ? true : false;
-  }
+    Path.prototype.update = function () {
+        return generalUpdate(this);
+    };
 
-  /*
-   * Constructor for new path instance
-   *
-   * @param {node} path actual dom node of the path
-   * @param {string} duration how long the animation should take to complete
-   * @param {string} easing the type of easing used - default is easeInOutCubic.
-   * @returns {Path}
-   */
+    /*
+     * Constructor for new Line instance
+     *
+     * @param {node} line actual dom node of the path
+     * @param {string} duration how long the animation should take to complete
+     * @param {string} easing the type of easing used - default is easeInOutCubic.
+     * @returns {line}
+     */
 
-  function Path(path, duration, easing) {
-    this.el = path;
-    this.length = path.getTotalLength(); // total length of the path
-    this.duration = duration;
-    this.easing = easing;
-    this.animationStart = null;
-    this.animationStarted = false;
-  }
-
-  /*
-   * Updates path style until the animation is complete
-   *
-   * @returns {boolean} Returns true if the path animation is finished, false otherwise
-   */
-
-  Path.prototype.update = function() {
-    return generalUpdate(this);
-  };
-
-  /*
-   * Constructor for new Line instance
-   *
-   * @param {node} line actual dom node of the path
-   * @param {string} duration how long the animation should take to complete
-   * @param {string} easing the type of easing used - default is easeInOutCubic.
-   * @returns {line}
-   */
-
-  function Line(line, duration, easing) {
-    this.el = line;
-    this.length = getLineLength(line);
-    this.duration = duration;
-    this.easing = easing;
-    this.animationStart = null;
-    this.animationStarted = false;
-  }
-
-  /*
-   * Updates line style until the animation is complete
-   *
-   * @returns {boolean} Returns true if the line animation is finished, false otherwise
-   */
-
-  Line.prototype.update = function() {
-    return generalUpdate(this);
-  };
-
-  /*
-   * Constructor for new Polyline instance
-   *
-   * @param {node} polyline actual dom node of the path
-   * @param {string} duration how long the animation should take to complete
-   * @param {string} easing the type of easing used - default is easeInOutCubic.
-   * @returns {polyline}
-   */
-
-  function Polyline(polyline, duration, easing){
-    this.el = polyline;
-    this.length = getPolylineLength(polyline);
-    this.duration = duration;
-    this.easing = easing;
-    this.animationStart = null;
-    this.animationStarted = false;
-  }
-
-  /*
-   * Updates polyline style until the animation is complete
-   *
-   * @returns {boolean} Returns true if the line animation is finished, false otherwise
-   */
-
-  Polyline.prototype.update = function(){
-    return generalUpdate(this);
-  };
-
-  /*
-   * Calculates the length of a polyline using pythagoras theorem for each line segment
-   *
-   * @param {node} polyline The polyline element to calculate length of
-   * @returns {Number} Length of the polyline
-   */
-
-  function getPolylineLength(polyline) {
-    var dist = 0;
-    var x1, x2, y1, y2;
-
-    for(var i = 1; i < polyline.points.numberOfItems; i++){
-      x1 = polyline.points.getItem(i - 1) .x;
-      x2 = polyline.points.getItem(i).x;
-      y1 = polyline.points.getItem(i - 1) .y;
-      y2 = polyline.points.getItem(i).y;
-
-      dist += Math.sqrt(Math.pow((x1 - x2), 2) + Math.pow((y1 - y2), 2));
+    function Line(line, duration, easing, redrawOnFocus) {
+        this.el = line;
+        this.length = getLineLength(line);
+        this.duration = duration;
+        this.easing = easing;
+        this.animationStart = null;
+        this.animationStarted = false;
+        this.redrawOnFocus = redrawOnFocus;
     }
 
-    return dist;
-  }
+    /*
+     * Updates line style until the animation is complete
+     *
+     * @returns {boolean} Returns true if the line animation is finished, false otherwise
+     */
 
-  /*
-   * Calculates the length a line using pythagoras theorem
-   *
-   * @param {node} line The line element to calculate length of
-   * @returns {Number} Length of the line
-   */
+    Line.prototype.update = function () {
+        return generalUpdate(this);
+    };
 
-  function getLineLength(line) {
-    var x1 = line.getAttribute('x1');
-    var x2 = line.getAttribute('x2');
-    var y1 = line.getAttribute('y1');
-    var y2 = line.getAttribute('y2');
+    /*
+     * Constructor for new Polyline instance
+     *
+     * @param {node} polyline actual dom node of the path
+     * @param {string} duration how long the animation should take to complete
+     * @param {string} easing the type of easing used - default is easeInOutCubic.
+     * @returns {polyline}
+     */
 
-    return Math.sqrt(Math.pow((x1 - x2), 2) + Math.pow((y1 - y2), 2));
-  }
+    function Polyline(polyline, duration, easing, redrawOnFocus) {
+        this.el = polyline;
+        this.length = getPolylineLength(polyline);
+        this.duration = duration;
+        this.easing = easing;
+        this.animationStart = null;
+        this.animationStarted = false;
+        this.redrawOnFocus = redrawOnFocus;
+    }
 
-  return Walkway;
+    /*
+     * Updates polyline style until the animation is complete
+     *
+     * @returns {boolean} Returns true if the line animation is finished, false otherwise
+     */
+
+    Polyline.prototype.update = function () {
+        return generalUpdate(this);
+    };
+
+    /*
+     * Calculates the length of a polyline using pythagoras theorem for each line segment
+     *
+     * @param {node} polyline The polyline element to calculate length of
+     * @returns {Number} Length of the polyline
+     */
+
+    function getPolylineLength(polyline) {
+        var dist = 0;
+        var x1, x2, y1, y2;
+
+        for (var i = 1; i < polyline.points.length; i++) {
+            x1 = polyline.points[i - 1].x;
+            x2 = polyline.points[i].x;
+            y1 = polyline.points[i - 1].y;
+            y2 = polyline.points[i].y;
+
+            dist += Math.sqrt(Math.pow((x1 - x2), 2) + Math.pow((y1 - y2), 2));
+        }
+
+        return dist;
+    }
+
+    /*
+     * Calculates the length a line using pythagoras theorem
+     *
+     * @param {node} line The line element to calculate length of
+     * @returns {Number} Length of the line
+     */
+
+    function getLineLength(line) {
+        var x1 = line.getAttribute('x1');
+        var x2 = line.getAttribute('x2');
+        var y1 = line.getAttribute('y1');
+        var y2 = line.getAttribute('y2');
+
+        return Math.sqrt(Math.pow((x1 - x2), 2) + Math.pow((y1 - y2), 2));
+    }
+
+    return Walkway;
 }));


### PR DESCRIPTION
Added new boolean option «redrawOnFocus» and custom logic for
processing tab focus change.

On «redrawOnFocus» true, every object will be redrawn from scratch
every time user change active tab. Changing active window in OS will
have no effect.

Callback function will not execute for obvious reasons. Such behavior
can impact performance on a page and can lead to multiple complex
callback functions calls.

We can set a parameter to check if animation was done at least once,
but I will hold it for future pull requests.

If we leave «redrawOnCallback» undefined or set to false, everything
will work as intended. Callback function will execute.