### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install walkway.js
 
 #### CDN
 ```
-http://cdn.jsdelivr.net/walkway/0.0.7/walkway.min.js
+https://cdn.jsdelivr.net/npm/walkway.js@0.0.6/src/walkway.min.js
 ```
 
 ## How to use


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.
I also noticed that the latest version is not available on npm.

You can find links for all files at https://www.jsdelivr.com/package/npm/walkway.js.

Feel free to ping me if you have any questions regarding this change.